### PR TITLE
Add CO2 emissions tracking and handle all ships reaching destination

### DIFF
--- a/src/ShipNetSimCore/ship/ship.cpp
+++ b/src/ShipNetSimCore/ship/ship.cpp
@@ -2766,6 +2766,7 @@ QJsonObject Ship::getCurrentStateAsJson() const
         fuelConsumptionArray.append(fuelJson);
     }
     stateJson["fuelConsumption"] = fuelConsumptionArray;
+    stateJson["carbonDioxideEmitted"] = getTotalCO2Emissions().value();
     json["consumption"] = stateJson;
 
     // Add energy sources (as an array)

--- a/src/ShipNetSimCore/simulatorapi.cpp
+++ b/src/ShipNetSimCore/simulatorapi.cpp
@@ -1065,6 +1065,12 @@ void SimulatorAPI::setupConnections(const QString& networkName, Mode mode)
 
     auto& simulator = apiData.simulator;
 
+    connect(simulator,
+            &ShipNetSimCore::Simulator::allShipsReachedDestination, this,
+            [this, networkName]() {
+                handleAllShipsReachedDestination(networkName);
+            });
+
     // Connect simulation results available signal
     connect(simulator,
             &ShipNetSimCore::Simulator::simulationResultsAvailable, this,
@@ -1183,6 +1189,11 @@ void SimulatorAPI::handleShipReachedDestination(QString networkName,
     response[networkName] = networkData;
 
     emit shipsReachedDestination(response);
+}
+
+void SimulatorAPI::handleAllShipsReachedDestination(QString networkName)
+{
+    emit allShipsReachedDestination(networkName);
 }
 
 void SimulatorAPI::handleResultsAvailable(QString networkName,

--- a/src/ShipNetSimCore/simulatorapi.h
+++ b/src/ShipNetSimCore/simulatorapi.h
@@ -226,6 +226,14 @@ signals:
                                 const QVector<QString> shipIDs);
 
     /**
+     * @brief Emitted when all ships in the simulation have reached their
+     *          destination
+     * @param networkName Name of the network where all ships
+     *          reached destination
+     */
+    void allShipsReachedDestination(const QString networkName);
+
+    /**
     * @brief Emitted when simulation results are ready for retrieval.
     * @param results Map of network names to their respective simulation
     * results
@@ -761,6 +769,15 @@ protected slots:
     */
     void handleProgressUpdate(QString networkName,
                               int progress);
+
+    /**
+     * @brief Handler for all ships reaching their destination
+     * @param networkName Network providing results
+     *
+     * @details Processes simulation signal of all ships reached their
+     * destination and emits allShipsReachedDestination signal
+     */
+    void handleAllShipsReachedDestination(QString networkName);
 
     /**
     * @brief Handler for simulation results

--- a/src/ShipNetSimServer/SimulationServer.h
+++ b/src/ShipNetSimServer/SimulationServer.h
@@ -58,6 +58,7 @@ private slots:
                                     int progressPercentage);
     void onShipAddedToSimulator(const QString networkName,
                                 const QVector<QString> shipIDs);
+    void onAllShipsReachDestination(const QString networkName);
     void onShipReachedDestination(const QJsonObject shipStatus);
     void onSimulationResultsAvailable(QPair<QString, ShipsResults> results);
     void onShipStateAvailable(QString networkName, QString shipID,

--- a/src/ShipNetSimServer/simulationserver.cpp
+++ b/src/ShipNetSimServer/simulationserver.cpp
@@ -55,6 +55,9 @@ void SimulationServer::setupServer() {
             &SimulatorAPI::shipsReachedDestination, this,
             &SimulationServer::onShipReachedDestination);
     connect(&SimulatorAPI::InteractiveMode::getInstance(),
+            &SimulatorAPI::allShipsReachedDestination, this,
+            &SimulationServer::onAllShipsReachDestination);
+    connect(&SimulatorAPI::InteractiveMode::getInstance(),
             &SimulatorAPI::simulationResultsAvailable, this,
             &SimulationServer::onSimulationResultsAvailable);
     connect(&SimulatorAPI::InteractiveMode::getInstance(),
@@ -919,7 +922,7 @@ void SimulationServer::onSimulationNetworkLoaded(QString networkName) {
     sendRabbitMQMessage(PUBLISHING_ROUTING_KEY.c_str(),
                         jsonMessage);
 
-    onWorkerReady();
+    // onWorkerReady();
 }
 
 void SimulationServer::onSimulationCreated(QString networkName) {
@@ -1078,6 +1081,15 @@ void SimulationServer::onShipAddedToSimulator(const QString networkName,
     onWorkerReady();
 }
 
+void SimulationServer::onAllShipsReachDestination(const QString networkName) {
+    QJsonObject jsonMessage;
+    jsonMessage["event"] = "allShipsReachedDestination";
+    jsonMessage["host"] = ShipNetSim_NAME;
+    sendRabbitMQMessage(PUBLISHING_ROUTING_KEY.c_str(),
+                        jsonMessage);
+    onWorkerReady();
+}
+
 void SimulationServer::onShipReachedDestination(const QJsonObject shipStatus) {
     QJsonObject jsonMessage;
     jsonMessage["event"] = "shipReachedDestination";
@@ -1085,8 +1097,6 @@ void SimulationServer::onShipReachedDestination(const QJsonObject shipStatus) {
     jsonMessage["host"] = ShipNetSim_NAME;
     sendRabbitMQMessage(PUBLISHING_ROUTING_KEY.c_str(),
                         jsonMessage);
-
-    onWorkerReady();
 }
 
 void SimulationServer::onShipStateAvailable(QString networkName,
@@ -1101,7 +1111,7 @@ void SimulationServer::onShipStateAvailable(QString networkName,
     sendRabbitMQMessage(PUBLISHING_ROUTING_KEY.c_str(),
                         jsonMessage);
 
-    onWorkerReady();
+    // onWorkerReady();
 }
 
 void SimulationServer::
@@ -1114,7 +1124,7 @@ void SimulationServer::
     sendRabbitMQMessage(PUBLISHING_ROUTING_KEY.c_str(),
                         jsonMessage);
 
-    onWorkerReady();
+    // onWorkerReady();
 }
 
 void SimulationServer::onSimulationResultsAvailable(
@@ -1128,7 +1138,7 @@ void SimulationServer::onSimulationResultsAvailable(
     sendRabbitMQMessage(PUBLISHING_ROUTING_KEY.c_str(),
                         jsonMessage);
 
-    onWorkerReady();
+    // onWorkerReady();
 }
 
 void SimulationServer::onContainersAddedToShip(QString networkName,
@@ -1160,7 +1170,7 @@ void SimulationServer::onShipReachedSeaPort(
     sendRabbitMQMessage(PUBLISHING_ROUTING_KEY.c_str(),
                         jsonMessage);
 
-    onWorkerReady();
+    // onWorkerReady();
 }
 
 void SimulationServer::onPortsAvailable(QMap<QString,


### PR DESCRIPTION
Introduce CO2 emissions data to ship state output and implement handling for when all ships reach their destination. Update signal connections to accommodate new events.